### PR TITLE
add dependency for building h5py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:buster-slim
 # Dependencies
 RUN apt update \
     && apt install -y \
+      pkg-config \
       libhdf5-dev \
       python3-numpy \
       python3-pip \


### PR DESCRIPTION
When building the docker image, the following error occurred:
```bash
    Building h5py requires pkg-config unless the HDF5 path is explicitly specified using the environment variable HDF5_DIR. For more information and details, see https://docs.h5py.org/en/stable/build.html#custom-installation
    error: pkg-config probably not installed: FileNotFoundError(2, "No such file or directory: 'pkg-config'")
```